### PR TITLE
A (partial) solution to issue #13

### DIFF
--- a/TransportDroidIL/src/net/lutzky/transportdroidil/AutolocationTextView.java
+++ b/TransportDroidIL/src/net/lutzky/transportdroidil/AutolocationTextView.java
@@ -226,7 +226,8 @@ public class AutolocationTextView extends EnhancedTextView {
 		}
 		
 	    //required field that makes Parcelables from a Parcel
-	    public static final Parcelable.Creator<SavedState> CREATOR =
+	    @SuppressWarnings("unused")
+		public static final Parcelable.Creator<SavedState> CREATOR =
 	        new Parcelable.Creator<SavedState>() {
 	          public SavedState createFromParcel(Parcel in) {
 	            return new SavedState(in);

--- a/TransportDroidIL/src/net/lutzky/transportdroidil/AutolocationTextView.java
+++ b/TransportDroidIL/src/net/lutzky/transportdroidil/AutolocationTextView.java
@@ -11,6 +11,8 @@ import android.location.Location;
 import android.location.LocationListener;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.util.Log;
 
@@ -176,5 +178,62 @@ public class AutolocationTextView extends EnhancedTextView {
 			setState(State.CUSTOM);
 		}
 		super.onTextChanged(text, start, before, after);
+	}
+	
+	// Save and restore state.
+	// See: http://stackoverflow.com/questions/3542333/how-to-prevent-custom-views-from-losing-state-across-screen-orientation-changes/3542895#3542895
+	
+	@Override
+	public Parcelable onSaveInstanceState() {
+		Parcelable parent = super.onSaveInstanceState();
+		SavedState s = new SavedState(parent);
+		s.state = getState();
+		return s;
+	}
+	
+	@Override
+	public void onRestoreInstanceState(Parcelable state) {
+	    //begin boilerplate code so parent classes can restore state
+	    if(!(state instanceof SavedState)) {
+	      super.onRestoreInstanceState(state);
+	      return;
+	    }
+
+	    SavedState ss = (SavedState)state;
+	    super.onRestoreInstanceState(ss.getSuperState());
+	    //end
+
+	    this.setState(ss.state);
+	}
+	
+	private static class SavedState extends BaseSavedState
+	{
+		public State state;
+		
+		public SavedState(Parcelable parent) {
+			super(parent);
+		}
+		
+		private SavedState(Parcel in) {
+			super(in);
+			this.state = State.valueOf(in.readString());
+		}
+		
+		@Override
+		public void writeToParcel(Parcel dest, int flags) {
+			super.writeToParcel(dest, flags);
+			dest.writeString(this.state.toString());
+		}
+		
+	    //required field that makes Parcelables from a Parcel
+	    public static final Parcelable.Creator<SavedState> CREATOR =
+	        new Parcelable.Creator<SavedState>() {
+	          public SavedState createFromParcel(Parcel in) {
+	            return new SavedState(in);
+	          }
+	          public SavedState[] newArray(int size) {
+	            return new SavedState[size];
+	          }
+	    };
 	}
 }

--- a/TransportDroidILTest/src/net/lutzky/transportdroidil/test/TransportDroidILTest.java
+++ b/TransportDroidILTest/src/net/lutzky/transportdroidil/test/TransportDroidILTest.java
@@ -1,0 +1,41 @@
+package net.lutzky.transportdroidil.test;
+
+import net.lutzky.transportdroidil.AutolocationTextView;
+import net.lutzky.transportdroidil.AutolocationTextView.State;
+import net.lutzky.transportdroidil.R;
+import net.lutzky.transportdroidil.TransportDroidIL;
+import android.os.Bundle;
+import android.test.ActivityInstrumentationTestCase2;
+import android.test.UiThreadTest;
+
+public class TransportDroidILTest extends ActivityInstrumentationTestCase2<TransportDroidIL> {
+
+	public TransportDroidILTest() {
+		super("net.lutzky.transportdroidil", TransportDroidIL.class);
+	}
+	
+	@UiThreadTest
+	public void testOrientation() throws InterruptedException {
+		TransportDroidIL activity = getActivity();
+		AutolocationTextView fromField = (AutolocationTextView) activity.findViewById(R.id.query_from);
+		
+		// Set custom state by typing something
+		fromField.requestFocus();
+		fromField.setText("Test");
+
+		assertEquals("Test", fromField.getText().toString());
+		assertEquals(State.CUSTOM, fromField.getState());
+		
+		// Change orientation simulation
+		Bundle icicle = new Bundle();
+		getInstrumentation().callActivityOnSaveInstanceState(activity, icicle);
+		activity.finish();
+		getInstrumentation().callActivityOnCreate(activity, null);
+		getInstrumentation().callActivityOnRestoreInstanceState(activity, icicle);
+		fromField = (AutolocationTextView) activity.findViewById(R.id.query_from);
+		
+		assertEquals("Test", fromField.getText().toString());
+		assertEquals(State.CUSTOM, fromField.getState());
+	}
+
+}


### PR DESCRIPTION
This commit makes the autolocation view save its complete state and restore it, which solves the issue with orientation changes.

I call it a partial solution, because I believe the geo-location class is still being destroyed and initialized again, but from a UI perspective this patch might be a good start.
